### PR TITLE
bump sslh v1.19b

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN BUILD_DEPS="gcc pcre-dev musl-dev make libconfig-dev"; \
-    VERSION=1.18; \
+    VERSION=1.19b; \
     apk --no-cache add pcre openssl libconfig $BUILD_DEPS && \
     cd /tmp && \
     wget -O sslh.zip https://github.com/yrutschle/sslh/archive/v$VERSION.zip && \


### PR DESCRIPTION
sslh v1.19b has released. https://github.com/yrutschle/sslh/releases